### PR TITLE
カバレッジ計測ジョブを追加

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,31 @@ jobs:
       - name: Run cargo test
         run: cargo test
 
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: llvm-tools-preview
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate coverage
+        run: cargo llvm-cov --lcov --output-path lcov.info
+
+      - uses: codecov/codecov-action@v2
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+
   fmt:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Rust 1.60.0 でカバレッジ計測のオプションが安定化したので、カバレッジ計測をしてその結果を可視化サイトにアップロードするようにした。