### PR TITLE
add job of coverage by grcov

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,31 +30,6 @@ jobs:
       - name: Run cargo test
         run: cargo test
 
-  coverage_by_llvm_cov:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: llvm-tools-preview
-          override: true
-
-      - uses: Swatinem/rust-cache@v1
-
-      - uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Generate coverage
-        run: cargo llvm-cov --lcov --output-path lcov.info
-
-      - uses: codecov/codecov-action@v2
-        with:
-          files: lcov.info
-          fail_ci_if_error: true
-
   coverage_by_grcov:
     runs-on: ubuntu-latest
 
@@ -78,10 +53,41 @@ jobs:
       - name: Generate coverage
         run: |
           cargo test
-          ./grcov . -s . --binary-path ./target/debug --ignore-not-existing -t lcov -o ./cov/lcov.info
+          ./grcov . -s . --binary-path ./target/debug --ignore-not-existing -t lcov -o ./coverage/lcov.info
+          ls -l ./coverage/lcov.info
         env:
           RUSTFLAGS: -C instrument-coverage
-          LLVM_PROFILE_FILE: "./cov/study-rust-%p-%m.profraw"
+          LLVM_PROFILE_FILE: "./coverage/study-rust-%p-%m.profraw"
+
+      - uses: codecov/codecov-action@v2
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: true
+
+  coverage_by_llvm_cov:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: llvm-tools-preview
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate coverage
+        run: cargo llvm-cov --lcov --output-path lcov.info
+
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: lcov.info
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run cargo test
         run: cargo test
 
-  coverage:
+  coverage_by_llvm_cov:
     runs-on: ubuntu-latest
 
     steps:
@@ -54,6 +54,34 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: true
+
+  coverage_by_grcov:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: llvm-tools-preview
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Install grcov
+        run: |
+          curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
+          ./grcov --version
+
+      - name: Generate coverage
+        run: |
+          cargo test
+          ./grcov . -s . --binary-path ./target/debug --ignore-not-existing -t lcov -o ./cov/lcov.info
+        env:
+          RUSTFLAGS: -C instrument-coverage
+          LLVM_PROFILE_FILE: "./cov/study-rust-%p-%m.profraw"
 
   fmt:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Rust](https://github.com/kuwata0037/study-rust/actions/workflows/rust.yml/badge.svg)](https://github.com/kuwata0037/study-rust/actions/workflows/rust.yml)
 [![codecov](https://codecov.io/gh/kuwata0037/study-rust/branch/master/graph/badge.svg?token=0OC3MY7OY6)](https://codecov.io/gh/kuwata0037/study-rust)
+[![Coverage Status](https://coveralls.io/repos/github/kuwata0037/study-rust/badge.svg)](https://coveralls.io/github/kuwata0037/study-rust)
 
 Rust 言語およびライブラリの個人学習用リポジトリ．
 


### PR DESCRIPTION
grcov を使用したカバレッジ計測ジョブの追加。
~~grcov で計測したカバレッジは coveralls へ送信する。~~
grcov で計測した結果を [Coveralls GitHub Action](https://github.com/marketplace/actions/coveralls-github-action) 経由で送信しようとしたらエラーとなったので、 Codecov へ送信するようにした。
代わりに #7 で追加した llvm-cov の計測結果を coveralls へ送信するように変更した。