### PR TITLE
opentelemetryパッケージのアップデートをグループ化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      opentelemetry:
+        patterns:
+          - "opentelemetry*"
+          - "tracing-opentelemetry"
+        update-types:
+          - "major"
+          - "minor"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
RustのOpentelemetryライブラリは`0.X.Y`のバージョン形式で、マイナーバージョンをアップデートした場合に、関連ライブラリをまとめてアップデートしないと互換性が崩れ、コンパイルに失敗するため、グループ化した。

ref: https://github.com/netlify/renovate-config/blob/abe45195e7bca5d49da033dc7c52b164603fe077/rust-default.json#L24-L25